### PR TITLE
fix: use `import` instead of `require` for `vite.config.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ exports.resolve = (source, file, config) => {
         if (!fs.existsSync(viteConfigPath)) {
             logError(`vite config file doesn't exist at '${viteConfigPath}'`);
         }
-        const viteConfigFile = require(viteConfigPath);
+        const viteConfigFile = import(viteConfigPath);
 
         let viteConfig;
         if (pluginConfig.namedExport) {


### PR DESCRIPTION
I'm getting `[ERR_REQUIRE_ESM]: require() of ES Module from not supported.` errors if `vite.config.js` is `require`d. Using `import` fixes this. Not sure if this is a good general solution though, so let me know if it has any unwanted side effects.