### PR TITLE
add `resolve^1.22.8` and `debug^4.3.4` as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "jest": "^29.5.0",
+        "resolve": "^1.22.8",
         "vite": "^5.0.12"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
+        "debug": "^4.3.4",
         "jest": "^29.5.0",
         "resolve": "^1.22.8",
         "vite": "^5.0.12"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "jest": "^29.5.0",
+    "resolve": "^1.22.8",
     "vite": "^5.0.12"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-import": "^2"
   },
   "devDependencies": {
+    "debug": "^4.3.4",
     "jest": "^29.5.0",
     "resolve": "^1.22.8",
     "vite": "^5.0.12"


### PR DESCRIPTION
https://github.com/pzmosquito/eslint-import-resolver-vite/blob/e0c140b25b3950c48f7b1e5806e7284304090d47/index.js#L2-L3
```
$ yarn eslint src
Required package: debug
Required by: eslint-import-resolver-vite@virtual:bccfffe86f6d3ed9eb3dd70b1b09ba999bd947159bbd2a9ba5af2f5b7388bf1648b16d33f78bc3de8834b031f04bd86863d1c7762fd258fb2ab8aa72c9ded4fc#npm:2.0.0 (via .yarn/__virtual__/eslint-import-resolver-vite-virtual-db0b409196/5/n0099/.yarn/berry/cache/eslint-import-resolver-vite-npm-2.0.0-4ae15c0a2d-10c0.zip/node_modules/eslint-import-resolver-vite/dist/)

Require stack:
- .yarn/__virtual__/eslint-import-resolver-vite-virtual-db0b409196/5/n0099/.yarn/berry/cache/eslint-import-resolver-vite-npm-2.0.0-4ae15c0a2d-10c0.zip/node_modules/eslint-import-resolver-vite/dist/index.cjs.js
- .yarn/__virtual__/eslint-module-utils-virtual-b2e9146db3/5/n0099/.yarn/berry/cache/eslint-module-utils-npm-2.8.0-05e42bcab0-10c0.zip/node_modules/eslint-module-utils/resolve.js
- .yarn/__virtual__/eslint-plugin-i-virtual-6b8d8c1acf/5/n0099/.yarn/berry/cache/eslint-plugin-i-npm-2.29.1-615997239b-10c0.zip/node_modules/eslint-plugin-i/lib/rules/no-unresolved.js
- .yarn/__virtual__/eslint-plugin-i-virtual-6b8d8c1acf/5/n0099/.yarn/berry/cache/eslint-plugin-i-npm-2.29.1-615997239b-10c0.zip/node_modules/eslint-plugin-i/lib/index.js
- .yarn/berry/cache/@eslint-eslintrc-npm-2.1.4-1ff4b5f908-10c0.zip/node_modules/@eslint/eslintrc/dist/eslintrc.cjs
    at require$$0.Module._resolveFilename (.pnp.cjs:13473:13)
    at Module._load (node:internal/modules/cjs/loader:901:27)
    at require$$0.Module._load (.pnp.cjs:13364:31)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (.yarn/__virtual__/eslint-import-resolver-vite-virtual-db0b409196/5/n0099/.yarn/berry/cache/eslint-import-resolver-vite-npm-2.0.0-4ae15c0a2d-10c0.zip/node_modules/eslint-import-resolver-vite/dist/index.cjs.js:1:123)
    at Module._compile (node:internal/modules/cjs/loader:1233:14)
    at require.Module._extensions [as .js] (.yarn/berry/cache/@httptoolkit-esm-npm-3.3.0-7df4a4e361-10c0.zip/node_modules/@httptoolkit/esm/esm.js:1:61)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
```
https://yarnpkg.com/features/pnp#how-can-i-fix-ghost-dependencies
https://yarnpkg.com/configuration/yarnrc#packageExtensions
https://github.com/import-js/eslint-plugin-import/blob/7a21f7e10f18c04473faadca94928af6b8e28009/resolvers/node/package.json#L34
The eslint rule [`import/no-extraneous-dependencies`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) might be helpful for detecting these issues.