### PR TITLE
Enable subpath imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,24 @@ module.exports = {
     }
 }
 ```
+
+#### Subpath resolution
+
+In addition to standard segment-based alias resolution, you can define aliases for complete module paths including subpaths. The resolver checks for exact full path matches first before falling back to segment-based replacements.
+
+```js
+export const viteConfigObj = {
+    resolve: {
+        alias: {
+            "@utils": path.resolve(__dirname, "src/utils"),
+            "@utils/api/client": path.resolve(__dirname, "src/api/client"), // Full path alias
+        },
+    },
+};
+
+// In your code:
+import { apiClient } from "@utils/api/client"; // ✓ resolves to src/api/client
+import { helper } from "@utils/helpers"; // ✓ resolves to src/utils/helpers
+```
+
+This works with both object-based and array-based alias configurations.

--- a/index.js
+++ b/index.js
@@ -8,23 +8,17 @@ const processAlias = (alias, source) => {
     if (alias) {
         const pathParts = path.normalize(source).split(path.sep);
         if (Array.isArray(alias)) {
+            // module/subpath alias
+            const exact = alias.find(({ find }) => find === source);
+            if (exact) {
+                return exact.replacement;
+            }
             for (let i = 0; i < pathParts.length; i++) {
-                let subpathReplacement;
-
                 alias.forEach(({ find, replacement }) => {
-                    // module/subpath alias
-                    if (find === source) {
-                        subpathReplacement = replacement;
-                    }
-
                     if (pathParts[i] === find) {
                         pathParts[i] = replacement;
                     }
                 });
-
-                if (subpathReplacement !== undefined) {
-                    return subpathReplacement;
-                }
             }
         } else if (typeof alias === "object") {
             // module/subpath alias

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const processAlias = (alias, source) => {
                     }
                 });
 
-                if (subpathReplacement !== null) {
+                if (subpathReplacement !== undefined) {
                     return subpathReplacement;
                 }
             }

--- a/index.js
+++ b/index.js
@@ -9,14 +9,29 @@ const processAlias = (alias, source) => {
         const pathParts = path.normalize(source).split(path.sep);
         if (Array.isArray(alias)) {
             for (let i = 0; i < pathParts.length; i++) {
-                alias.forEach(({find, replacement}) => {
+                let subpathReplacement;
+
+                alias.forEach(({ find, replacement }) => {
+                    // module/subpath alias
+                    if (find === source) {
+                        subpathReplacement = replacement;
+                    }
+
                     if (pathParts[i] === find) {
                         pathParts[i] = replacement;
                     }
                 });
+
+                if (subpathReplacement) {
+                    return subpathReplacement;
+                }
             }
         }
         else if (typeof alias === "object") {
+            // module/subpath alias
+            if (alias[source]) {
+                return alias[source];
+            }
             for (let i = 0; i < pathParts.length; i++) {
                 if (alias.hasOwnProperty(pathParts[i])) {
                     pathParts[i] = alias[pathParts[i]];

--- a/index.js
+++ b/index.js
@@ -22,14 +22,13 @@ const processAlias = (alias, source) => {
                     }
                 });
 
-                if (subpathReplacement) {
+                if (subpathReplacement !== null) {
                     return subpathReplacement;
                 }
             }
-        }
-        else if (typeof alias === "object") {
+        } else if (typeof alias === "object") {
             // module/subpath alias
-            if (alias[source]) {
+            if (alias.hasOwnProperty(source)) {
                 return alias[source];
             }
             for (let i = 0; i < pathParts.length; i++) {
@@ -37,9 +36,10 @@ const processAlias = (alias, source) => {
                     pathParts[i] = alias[pathParts[i]];
                 }
             }
-        }
-        else {
-            throw new Error("The alias must be either an object, or an array of objects.");
+        } else {
+            throw new Error(
+                "The alias must be either an object, or an array of objects.",
+            );
         }
         return pathParts.join(path.sep);
     }
@@ -75,16 +75,14 @@ exports.resolve = (source, file, config) => {
     // try to resolve the source as is
     try {
         return resolveSync(source, resolveOptions, "as is");
-    }
-    catch {}
+    } catch {}
 
     // try to resolve the source with alias
     const parsedSource = processAlias(alias, source);
     if (parsedSource !== source) {
         try {
             return resolveSync(parsedSource, resolveOptions, "with alias");
-        }
-        catch {}
+        } catch {}
     }
 
     // try to resolve the source if it is an absolute path
@@ -93,8 +91,7 @@ exports.resolve = (source, file, config) => {
         const absoluteSource = path.join(path.resolve(root), parsedSource);
         try {
             return resolveSync(absoluteSource, resolveOptions, "absolute path");
-        }
-        catch {}
+        } catch {}
     }
 
     // try to resolve the source in public directory if all above failed
@@ -102,9 +99,12 @@ exports.resolve = (source, file, config) => {
         const publicDir = viteConfig.publicDir ?? "public";
         const publicSource = path.join(path.resolve(publicDir), parsedSource);
         try {
-            return resolveSync(publicSource, resolveOptions, "in public directory");
-        }
-        catch {}
+            return resolveSync(
+                publicSource,
+                resolveOptions,
+                "in public directory",
+            );
+        } catch {}
     }
 
     log("ERROR:\t", "Unable to resolve");
@@ -116,6 +116,6 @@ exports.createViteImportResolver = (config) => {
     return {
         interfaceVersion: 3,
         name: "eslint-import-resolver-vite",
-        resolve: (source, file) => exports.resolve(source, file, config)
+        resolve: (source, file) => exports.resolve(source, file, config),
     };
-}
+};

--- a/index.test.js
+++ b/index.test.js
@@ -73,6 +73,71 @@ describe("Resolver Plugin Tests", () => {
         );
     });
 
+    test("should resolve non-core subpath module (array alias pairs)", () => {
+        resolve.sync = jest.fn((source) => {
+            // console.log("SOURCE: ", source);
+            if (source === "/path/to/module/subpath.js") {
+                return "/path/to/module/subpath.js";
+            }
+            throw new Error("Resolve error");
+        });
+
+        const viteConfig = {
+            resolve: {
+                extensions: [".js"],
+                alias: [
+                    {
+                        find: "module/subpath",
+                        replacement: "/path/to/module/subpath.js",
+                    },
+                ],
+            },
+        };
+
+        // JS module
+        let result = resolver.resolve("module/subpath", "/path/to/file.js", {
+            viteConfig,
+        });
+
+        expect(result.found).toBe(true);
+        expect(result.path).toBe("/path/to/module/subpath.js");
+        expect(resolve.sync).toHaveBeenCalledWith("module/subpath", {
+            basedir: "/path/to",
+            extensions: [".js"],
+        });
+    });
+
+    test("should resolve non-core subpath module (object pairs)", () => {
+        resolve.sync = jest.fn((source) => {
+            // console.log("SOURCE: ", source);
+            if (source === "/path/to/module/subpath.js") {
+                return "/path/to/module/subpath.js";
+            }
+            throw new Error("Resolve error");
+        });
+
+        const viteConfig = {
+            resolve: {
+                extensions: [".js"],
+                alias: {
+                    "module/subpath": "/path/to/module/subpath.js",
+                },
+            },
+        };
+
+        // JS module
+        let result = resolver.resolve("module/subpath", "/path/to/file.js", {
+            viteConfig,
+        });
+
+        expect(result.found).toBe(true);
+        expect(result.path).toBe("/path/to/module/subpath.js");
+        expect(resolve.sync).toHaveBeenCalledWith("module/subpath", {
+            basedir: "/path/to",
+            extensions: [".js"],
+        });
+    });
+
     test("should throw error when viteConfig is not an object", () => {
         const viteConfig = null;
 

--- a/index.test.js
+++ b/index.test.js
@@ -105,6 +105,14 @@ describe("Resolver Plugin Tests", () => {
             basedir: "/path/to",
             extensions: [".js"],
         });
+        expect(resolve.sync).toHaveBeenNthCalledWith(
+            2,
+            "/path/to/module/subpath.js",
+            {
+                basedir: "/path/to",
+                extensions: [".js"],
+            },
+        );
     });
 
     test("should resolve non-core subpath module (object pairs)", () => {
@@ -136,6 +144,14 @@ describe("Resolver Plugin Tests", () => {
             basedir: "/path/to",
             extensions: [".js"],
         });
+        expect(resolve.sync).toHaveBeenNthCalledWith(
+            2,
+            "/path/to/module/subpath.js",
+            {
+                basedir: "/path/to",
+                extensions: [".js"],
+            },
+        );
     });
 
     test("should throw error when viteConfig is not an object", () => {


### PR DESCRIPTION
💡 Summary

Adds support for subpath imports in Vite alias resolution.
Previously, the resolver only handled direct alias matches (e.g. "@/components"), but not subpath imports such as "module/subpath".

🧩 Changes

- Update the resolver logic to handle subpath alias resolution for both array and object alias configurations in vite.config.js.
- Add new test cases to ensure correct behavior for:
  - Array-based alias definitions ([{ find, replacement }])
  - Object-based alias definitions ({ "find": "replacement" })

🧠 Motivation

Projects using Vite often rely on subpath imports (e.g., `module/subpath`) to maintain clean and modular code structures. This change ensures that ESLint import resolution stays consistent with Vite’s native alias resolution behavior.